### PR TITLE
Fixed bugs in cadc dataset loader and updated yamls

### DIFF
--- a/pcdet/datasets/cadc/cadc_dataset.py
+++ b/pcdet/datasets/cadc/cadc_dataset.py
@@ -4,10 +4,10 @@ import pickle
 import copy
 import numpy as np
 import json
+import math
 from skimage import io
 from pathlib import Path
 import torch
-import spconv
 
 from ...utils import box_utils, common_utils
 from ..dataset import DatasetTemplate
@@ -15,6 +15,7 @@ from ...ops.roiaware_pool3d import roiaware_pool3d_utils
 from pcdet.config import cfg
 from pcdet.datasets.cadc import cadc_calibration
 
+import time
 
 class CadcDataset(DatasetTemplate):
     def __init__(self, dataset_cfg, class_names, training=True, root_path=None, logger=None):
@@ -29,10 +30,14 @@ class CadcDataset(DatasetTemplate):
         super().__init__(
             dataset_cfg=dataset_cfg, class_names=class_names, training=training, root_path=root_path, logger=logger
         )
+        self.imagesets_path = Path(self.dataset_cfg.DATA_PATH)
+        if root_path != None: # Image sets information
+            self.imagesets_path = root_path
+        self.root_path = Path(self.dataset_cfg.DATA_PATH) # Path to the actual data
         self.split = self.dataset_cfg.DATA_SPLIT[self.mode]
         self.root_split_path = self.root_path / ('training' if self.split != 'test' else 'testing')
 
-        split_dir = self.root_path / 'ImageSets' / (self.split + '.txt')
+        split_dir = self.imagesets_path / 'ImageSets' / (self.split + '.txt')
         self.sample_id_list = [x.strip().split(' ') for x in open(split_dir).readlines()] if split_dir.exists() else None
 
         self.cadc_infos = []
@@ -63,7 +68,7 @@ class CadcDataset(DatasetTemplate):
         self.split = split
         self.root_split_path = self.root_path / ('training' if self.split != 'test' else 'testing')
 
-        split_dir = self.root_path / 'ImageSets' / (self.split + '.txt')
+        split_dir = self.imagesets_path / 'ImageSets' / (self.split + '.txt')
         self.sample_id_list = [x.strip().split(' ') for x in open(split_dir).readlines()] if split_dir.exists() else None
 
     def get_lidar(self, sample_idx):
@@ -71,7 +76,6 @@ class CadcDataset(DatasetTemplate):
         lidar_file = os.path.join(self.root_path, date, set_num, 'labeled', 'lidar_points', 'data', '%s.bin' % idx)
         assert os.path.exists(lidar_file)
         points = np.fromfile(lidar_file, dtype=np.float32).reshape(-1, 4)
-        points[:, 3] /= 255
         return points
 
     def get_image_shape(self, sample_idx):
@@ -148,15 +152,14 @@ class CadcDataset(DatasetTemplate):
                 else:
                     continue
             # filter by point_count
-            if obj['points_count'] < point_count_threshold[obj['label']]:
+            if obj['points_count'] == 0:
                 ratio_to_criteria = obj['points_count'] / point_count_threshold[obj['label']]
                 if ratio_to_criteria > closest_ratio_to_criteria:
                     closest_idx_to_criteria = idx
                 continue
             # filter by distance
             x, y, z = obj['position']['x'],obj['position']['y'],obj['position']['z']
-            distance = np.sqrt(np.square(x)+np.square(y)+np.square(z))
-            if distance > distance_threshold:
+            if abs(x) > distance_threshold or abs(y) > distance_threshold:
                 continue
             obj_list.append(obj)
         
@@ -168,28 +171,51 @@ class CadcDataset(DatasetTemplate):
 
         annotations = {}
         annotations['name'] = np.array([obj['label'] for obj in obj_list])
-        annotations['num_points_in_gt'] = [[obj['points_count'] for obj in obj_list]]
+        annotations['num_points_in_gt'] = np.array([obj['points_count'] for obj in obj_list])
         
-        loc_lidar = np.array([[obj['position']['x'],obj['position']['y'],obj['position']['z']] for obj in obj_list]) 
-        dims = np.array([[obj['dimensions']['x'],obj['dimensions']['y'],obj['dimensions']['z']] for obj in obj_list])
+        loc_lidar = np.array([[obj['position']['x'],obj['position']['y'],obj['position']['z']] for obj in obj_list])
+        # Scale AI gives x as width and y as length, we must switch these
+        dims = np.array([[obj['dimensions']['y'],obj['dimensions']['x'],obj['dimensions']['z']] for obj in obj_list])
         rots = np.array([obj['yaw'] for obj in obj_list])
         gt_boxes_lidar = np.concatenate([loc_lidar, dims, rots[..., np.newaxis]], axis=1)
         annotations['gt_boxes_lidar'] = gt_boxes_lidar
         
         # in camera 0 frame. Probably meaningless as most objects aren't in frame.
-        annotations['location'] = calib.lidar_to_rect(loc_lidar) 
+        annotations['location'] = calib.lidar_to_rect(loc_lidar)
         annotations['rotation_y'] = rots
+        # Scale AI gives x as width and y as length, we must switch these
         annotations['dimensions'] = np.array([[obj['dimensions']['y'], obj['dimensions']['z'], obj['dimensions']['x']] for obj in obj_list])  # lhw format
-        
-        gt_boxes_camera = box_utils.boxes3d_lidar_to_kitti_camera(gt_boxes_lidar, calib)
-        
+
+        # Should not be modifying the original lidar positions
+        gt_boxes_copy = copy.deepcopy(gt_boxes_lidar)
+        gt_boxes_camera = box_utils.boxes3d_lidar_to_kitti_camera(gt_boxes_copy, calib)
+        gt_boxes_img = box_utils.boxes3d_kitti_camera_to_imageboxes(
+            gt_boxes_camera, calib, image_shape=self.get_image_shape(sample_idx)
+        )
+
+        # Calculate occluded levels for testing
+        point_levels = [15, 5, 1]
+        dist_levels = [30.0, 50.0, 75.0] # 75.0 will cover max diagonal distance
+        occluded_list = []
+        for obj in obj_list:
+            dist_to_obj = math.sqrt(obj['position']['x']**2 + obj['position']['y']**2)
+            if obj['points_count'] >= point_levels[0] and dist_to_obj <= dist_levels[0]:
+                occluded_list.append(0) # fully visible
+            elif obj['points_count'] >= point_levels[1] and dist_to_obj <= dist_levels[1]:
+                occluded_list.append(1) # partly occluded
+            elif obj['points_count'] >= point_levels[2] and dist_to_obj <= dist_levels[2]:
+                occluded_list.append(2) # largely occluded
+            else:
+                occluded_list.append(3) # unknown
+
+        annotations['occluded'] = np.array(occluded_list)
+
         # Currently unused for CADC, and don't make too much since as we primarily use 360 degree 3d LIDAR boxes.
         annotations['score'] = np.array([1 for _ in obj_list])
         annotations['difficulty'] = np.array([0 for obj in obj_list], np.int32)
         annotations['truncated'] = np.array([0 for _ in obj_list])
-        annotations['occluded'] = np.array([0 for _ in obj_list])
         annotations['alpha'] = np.array([-np.arctan2(-gt_boxes_lidar[i][1], gt_boxes_lidar[i][0]) + gt_boxes_camera[i][6] for i in range(len(obj_list))]) 
-        annotations['bbox'] = gt_boxes_camera
+        annotations['bbox'] = gt_boxes_img
         
         return annotations
     
@@ -331,15 +357,15 @@ class CadcDataset(DatasetTemplate):
             pred_scores = box_dict['pred_scores'].cpu().numpy()
             pred_boxes = box_dict['pred_boxes'].cpu().numpy()
             pred_labels = box_dict['pred_labels'].cpu().numpy()
-
-            calib = batch_dict['calib'][batch_index]
-            image_shape = batch_dict['image_shape'][batch_index]
-            pred_boxes_camera = box_utils.boxes3d_lidar_to_kitti_camera(pred_boxes, calib)
-
             pred_dict = get_template_prediction(pred_scores.shape[0])
             if pred_scores.shape[0] == 0:
                 return pred_dict
 
+            calib = batch_dict['calib'][batch_index]
+            image_shape = batch_dict['image_shape'][batch_index]
+            # Should not be modifying the original lidar positions
+            pred_boxes_copy = copy.deepcopy(pred_boxes)
+            pred_boxes_camera = box_utils.boxes3d_lidar_to_kitti_camera(pred_boxes_copy, calib)
             pred_boxes_img = box_utils.boxes3d_kitti_camera_to_imageboxes(
                 pred_boxes_camera, calib, image_shape=image_shape
             )
@@ -357,7 +383,6 @@ class CadcDataset(DatasetTemplate):
 
         annos = []
         for index, box_dict in enumerate(pred_dicts):
-            # frame_id = batch_dict['frame_id'][index]
             frame_id = batch_dict['sample_idx'][index]
 
             single_pred_dict = generate_single_sample_dict(index, box_dict)
@@ -409,9 +434,6 @@ class CadcDataset(DatasetTemplate):
 
         for i in range(len(eval_det_annos)):
             boxes3d_lidar = np.array(eval_det_annos[i]['boxes_lidar'])
-            # Seems like the lidar location is wrt the center of (x,y) axis and bottom of z-axis
-            # Adding h/2 to it so that it's wrt to the center of z-axis, like the gt box
-            boxes3d_lidar[:, 2] += boxes3d_lidar[:, 5] / 2
             boxes3d_lidar = boxes3d_lidar[:,[1,0,2,3,4,5,6]]
             boxes3d_lidar[:,0] *= -1
             eval_det_annos[i]['location'] = boxes3d_lidar[:,:3]
@@ -431,7 +453,7 @@ class CadcDataset(DatasetTemplate):
         return len(self.cadc_infos)
 
     def __getitem__(self, index):
-        # index = 4
+        self.start_time = time.time()
         info = copy.deepcopy(self.cadc_infos[index])
 
         sample_idx = info['point_cloud']['lidar_idx']
@@ -453,20 +475,25 @@ class CadcDataset(DatasetTemplate):
 
         if 'annos' in info:
             annos = info['annos']
-            #annos = common_utils.drop_info_with_name(annos, name='DontCare')
-            loc, dims, rots = annos['location'], annos['dimensions'], annos['rotation_y']
-            gt_names = annos['name']
-            bbox = annos['bbox']
-            gt_boxes_camera = np.concatenate([loc, dims, rots[..., np.newaxis]], axis=1).astype(np.float32)
-            if 'gt_boxes_lidar' in annos:
-                gt_boxes_lidar = annos['gt_boxes_lidar']
+
+            # Create mask to filter annotations during training
+            if self.training and self.dataset_cfg.get('FILTER_MIN_POINTS_IN_GT', False):
+                mask = (annos['num_points_in_gt'] > self.dataset_cfg.FILTER_MIN_POINTS_IN_GT - 1)
             else:
+                mask = None
+
+            gt_names = annos['name'] if mask is None else annos['name'][mask]
+            if 'gt_boxes_lidar' in annos:
+                gt_boxes_lidar = annos['gt_boxes_lidar'] if mask is None else annos['gt_boxes_lidar'][mask]
+            else:
+                # This should not run, although the code should look somewhat like this
+                raise NotImplementedError
+                loc, dims, rots = annos['location'], annos['dimensions'], annos['rotation_y']
+                gt_boxes_camera = np.concatenate([loc, dims, rots[..., np.newaxis]], axis=1).astype(np.float32)
                 gt_boxes_lidar = box_utils.boxes3d_kitti_camera_to_lidar(gt_boxes_camera, calib)
 
             input_dict.update({
-                # 'gt_boxes': gt_boxes_camera,
                 'gt_names': gt_names,
-                # 'gt_box2d': bbox,
                 'gt_boxes': gt_boxes_lidar
             })
 
@@ -475,7 +502,7 @@ class CadcDataset(DatasetTemplate):
         data_dict['image_shape'] = img_shape
         return data_dict 
 
-def create_cadc_infos(dataset_cfg, class_names, data_path, save_path, workers=4):
+def create_cadc_infos(dataset_cfg, class_names, data_path, save_path, workers=8):
     dataset = CadcDataset(dataset_cfg=dataset_cfg, class_names=class_names, root_path=data_path, training=False)
     train_split, val_split = 'train', 'val'
 
@@ -526,5 +553,5 @@ if __name__ == '__main__':
             dataset_cfg=dataset_cfg,
             class_names=['Car', 'Pedestrian', 'Pickup_Truck'],
             data_path=ROOT_DIR / 'data' / 'cadc',
-            save_path=ROOT_DIR / 'data' / 'cadc'
+            save_path=Path(dataset_cfg.DATA_PATH)
         )

--- a/tools/cfgs/cadc_models/pointpillar.yaml
+++ b/tools/cfgs/cadc_models/pointpillar.yaml
@@ -2,7 +2,7 @@ CLASS_NAMES: ['Car', 'Pedestrian', 'Pickup_Truck']
 
 DATA_CONFIG: 
     _BASE_CONFIG_: cfgs/dataset_configs/cadc_dataset.yaml
-    POINT_CLOUD_RANGE: [-50, -50, -5, 50, 50, 3]
+    POINT_CLOUD_RANGE: [-51.2, -51.2, -3, 51.2, 51.2, 3]
     DATA_PROCESSOR:
         - NAME: mask_points_and_boxes_outside_range
           REMOVE_OUTSIDE_BOXES: True
@@ -10,15 +10,15 @@ DATA_CONFIG:
         - NAME: shuffle_points
           SHUFFLE_ENABLED: {
             'train': True,
-            'test': False
+            'test': True # Set to true like NuScenes
           }
 
         - NAME: transform_points_to_voxels
-          VOXEL_SIZE: [0.25, 0.25, 8]
-          MAX_POINTS_PER_VOXEL: 64
+          VOXEL_SIZE: [0.2, 0.2, 6]
+          MAX_POINTS_PER_VOXEL: 20
           MAX_NUMBER_OF_VOXELS: {
-            'train': 16000,
-            'test': 40000
+            'train': 30000,
+            'test': 30000
           }
 
 MODEL:
@@ -40,7 +40,7 @@ MODEL:
         LAYER_NUMS: [3, 5, 5]
         LAYER_STRIDES: [2, 2, 2]
         NUM_FILTERS: [64, 128, 256]
-        UPSAMPLE_STRIDES: [1, 2, 4]
+        UPSAMPLE_STRIDES: [0.5, 1, 2]
         NUM_UPSAMPLE_FILTERS: [128, 128, 128]
 
     DENSE_HEAD:
@@ -55,31 +55,31 @@ MODEL:
         ANCHOR_GENERATOR_CONFIG: [
             {
                 'class_name': 'Car',
-                'anchor_sizes': [[3.9, 1.6, 1.56]],
+                'anchor_sizes': [[4.58, 1.88, 1.67]],
                 'anchor_rotations': [0, 1.57],
-                'anchor_bottom_heights': [-1.78],
+                'anchor_bottom_heights': [-2.18],
                 'align_center': False,
-                'feature_map_stride': 2,
+                'feature_map_stride': 4,
                 'matched_threshold': 0.6,
                 'unmatched_threshold': 0.45
             },
             {
                 'class_name': 'Pedestrian',
-                'anchor_sizes': [[0.8, 0.6, 1.73]],
+                'anchor_sizes': [[0.80, 0.75, 1.76]],
                 'anchor_rotations': [0, 1.57],
-                'anchor_bottom_heights': [-0.6],
+                'anchor_bottom_heights': [-2.03],
                 'align_center': False,
-                'feature_map_stride': 2,
+                'feature_map_stride': 4,
                 'matched_threshold': 0.5,
                 'unmatched_threshold': 0.35
             },
             {
                 'class_name': 'Pickup_Truck',
-                'anchor_sizes': [[5.89, 2.03, 1.92]],
+                'anchor_sizes': [[5.76, 2.09, 2.01]],
                 'anchor_rotations': [0, 1.57],
-                'anchor_bottom_heights': [-0.6],
+                'anchor_bottom_heights': [-2.43],
                 'align_center': False,
-                'feature_map_stride': 2,
+                'feature_map_stride': 4,
                 'matched_threshold': 0.6,
                 'unmatched_threshold': 0.45
             }

--- a/tools/cfgs/cadc_models/second.yaml
+++ b/tools/cfgs/cadc_models/second.yaml
@@ -1,0 +1,136 @@
+CLASS_NAMES: ['Car', 'Pedestrian', 'Pickup_Truck']
+
+DATA_CONFIG: 
+    _BASE_CONFIG_: cfgs/dataset_configs/cadc_dataset.yaml
+    POINT_CLOUD_RANGE: [-51.2, -51.2, -3, 51.2, 51.2, 3]
+    DATA_PROCESSOR:
+        - NAME: mask_points_and_boxes_outside_range
+          REMOVE_OUTSIDE_BOXES: True
+
+        - NAME: shuffle_points
+          SHUFFLE_ENABLED: {
+            'train': True,
+            'test': True # Set to true like NuScenes
+          }
+
+        # Same as NuScenes SECOND with voxel z size change
+        - NAME: transform_points_to_voxels
+          VOXEL_SIZE: [0.1, 0.1, 0.15] # Must subdivide z to 40 (6 m / 0.15 m = 40)
+          MAX_POINTS_PER_VOXEL: 10
+          MAX_NUMBER_OF_VOXELS: {
+            'train': 60000,
+            'test': 60000
+          }
+
+MODEL:
+    NAME: SECONDNet
+
+    VFE:
+        NAME: MeanVFE
+
+    BACKBONE_3D:
+        NAME: VoxelBackBone8x
+
+    MAP_TO_BEV:
+        NAME: HeightCompression
+        NUM_BEV_FEATURES: 256
+
+    BACKBONE_2D:
+        NAME: BaseBEVBackbone
+
+        LAYER_NUMS: [5, 5]
+        LAYER_STRIDES: [1, 2]
+        NUM_FILTERS: [128, 256]
+        UPSAMPLE_STRIDES: [1, 2]
+        NUM_UPSAMPLE_FILTERS: [256, 256]
+
+    DENSE_HEAD:
+        NAME: AnchorHeadSingle
+        CLASS_AGNOSTIC: False
+
+        USE_DIRECTION_CLASSIFIER: True
+        DIR_OFFSET: 0.78539
+        DIR_LIMIT_OFFSET: 0.0
+        NUM_DIR_BINS: 2
+
+        ANCHOR_GENERATOR_CONFIG: [
+            {
+                'class_name': 'Car',
+                'anchor_sizes': [[4.58, 1.88, 1.67]],
+                'anchor_rotations': [0, 1.57],
+                'anchor_bottom_heights': [-2.18],
+                'align_center': False,
+                'feature_map_stride': 8,
+                'matched_threshold': 0.6,
+                'unmatched_threshold': 0.45
+            },
+            {
+                'class_name': 'Pedestrian',
+                'anchor_sizes': [[0.80, 0.75, 1.76]],
+                'anchor_rotations': [0, 1.57],
+                'anchor_bottom_heights': [-2.03],
+                'align_center': False,
+                'feature_map_stride': 8,
+                'matched_threshold': 0.5,
+                'unmatched_threshold': 0.35
+            },
+            {
+                'class_name': 'Pickup_Truck',
+                'anchor_sizes': [[5.76, 2.09, 2.01]],
+                'anchor_rotations': [0, 1.57],
+                'anchor_bottom_heights': [-2.43],
+                'align_center': False,
+                'feature_map_stride': 8,
+                'matched_threshold': 0.6,
+                'unmatched_threshold': 0.45
+            }
+        ]
+
+        TARGET_ASSIGNER_CONFIG:
+            NAME: AxisAlignedTargetAssigner
+            POS_FRACTION: -1.0
+            SAMPLE_SIZE: 512
+            NORM_BY_NUM_EXAMPLES: False
+            MATCH_HEIGHT: False
+            BOX_CODER: ResidualCoder
+
+        LOSS_CONFIG:
+            LOSS_WEIGHTS: {
+                'cls_weight': 1.0,
+                'loc_weight': 2.0,
+                'dir_weight': 0.2,
+                'code_weights': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+            }
+
+    POST_PROCESSING:
+        RECALL_THRESH_LIST: [0.3, 0.5, 0.7]
+        SCORE_THRESH: 0.1
+        OUTPUT_RAW_SCORE: False
+
+        EVAL_METRIC: cadc
+
+        NMS_CONFIG:
+            MULTI_CLASSES_NMS: False
+            NMS_TYPE: nms_gpu
+            NMS_THRESH: 0.01
+            NMS_PRE_MAXSIZE: 4096
+            NMS_POST_MAXSIZE: 500
+
+
+OPTIMIZATION:
+    OPTIMIZER: adam_onecycle
+    LR: 0.003
+    WEIGHT_DECAY: 0.01
+    MOMENTUM: 0.9
+
+    MOMS: [0.95, 0.85]
+    PCT_START: 0.4
+    DIV_FACTOR: 10
+    DECAY_STEP_LIST: [35, 45]
+    LR_DECAY: 0.1
+    LR_CLIP: 0.0000001
+
+    LR_WARMUP: False
+    WARMUP_EPOCH: 1
+
+    GRAD_NORM_CLIP: 10

--- a/tools/cfgs/dataset_configs/cadc_dataset.yaml
+++ b/tools/cfgs/dataset_configs/cadc_dataset.yaml
@@ -1,7 +1,8 @@
 DATASET: 'CadcDataset'
-DATA_PATH: '../data/cadc'
+DATA_PATH: '/root/cadc'
 
-POINT_CLOUD_RANGE: [-50, -50, -5, 50, 50, 3]
+POINT_CLOUD_RANGE: [-51.2, -51.2, -3, 51.2, 51.2, 3]
+FILTER_MIN_POINTS_IN_GT: 5 # Applied during training only
 
 DATA_SPLIT: {
     'train': train,
@@ -22,7 +23,7 @@ DATA_AUGMENTOR:
       DB_INFO_PATH:
           - cadc_dbinfos_train.pkl
       PREPARE: {
-         filter_by_min_points: ['Car:5', 'Pedestrian:5', 'Pickup_Truck:5'],
+         filter_by_min_points: ['Car:10', 'Pedestrian:10', 'Pickup_Truck:10'],
          filter_by_difficulty: [-1],
       }
 
@@ -44,8 +45,8 @@ DATA_AUGMENTOR:
 # Used to filter the ground truth annotations
 FILTER_CRITERIA: {
      filter_by_min_points: ['Car:5', 'Pedestrian:5', 'Pickup_Truck:5'],
-     distance: 60,
-     score: 0.2
+     distance: 50,
+     score: 0.1
 }
 
 POINT_FEATURE_ENCODING: {


### PR DESCRIPTION
CADC Dataset changes
- Now filters points during training like NuScenes
- Remove addition of height / 2.0 and instead copy pred_boxes before sending to boxes3d_lidar_to_kitti_camera function
- Set occluded level based on distance and number of points
- The point intensity is not divided by 255 anymore. Points are already stored in range [0,1]

Yaml changes
- Added SECOND config
- Changes anchor sizes and bottom heights based on objects
- New point cloud range and point filtering